### PR TITLE
Add ignore rules for generated assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Node modules
+node_modules/
+
+# Generated vendor libraries
+vendor/
+
+# Minified JavaScript files
+js/*.min.js
+js/*.min.js.map
+
+# jQuery distribution
+jquery/
+
+# OS metadata
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains the source code for the Oproepjes Nederland website.
    ```bash
    npm install
    ```
+Running this command installs front-end packages so you can rebuild the `vendor` directory and minified scripts.
 
 2. Start the asset watcher and development server:
 


### PR DESCRIPTION
## Summary
- ignore built assets in `.gitignore`
- document that `npm install` installs dependencies used to build vendor files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68481d43f1848324b46ab76b985dc20d