### PR TITLE
Remove SameSite attribute from inline scripts

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -20,7 +20,7 @@
 <script src="https://16hl07csd16.nl/cdn/oproepjes/js/bootstrap.bundle.min.js"></script>
 <script src="https://unpkg.com/vue-router@3.5.3"></script>
 
-<script type="text/javascript" nonce="<?php echo $nonce; ?>" SameSite=None; Secure>
+<script type="text/javascript" nonce="<?php echo $nonce; ?>">
 	////Random IMG
 	var topper = ['1.gif', '2.gif', '3.gif', '4.gif', '5.gif', '6.gif', '7.gif', '8.gif', '9.gif', '10.gif'];
 	$('<a href="https://testars-consin.icu/543064f4-6080-4845-8f43-30f049426cdf?site={ONL}"><img class="align-center" src="img/banners/' + topper[Math.floor(Math.random() * topper.length)] + '" alt="Spannende plekken om contact te maken"></a>').appendTo('#top-banner');

--- a/includes/header.php
+++ b/includes/header.php
@@ -179,8 +179,8 @@ $nonce = base64_encode(random_bytes(16));
     <meta name="twitter:url" content="<?php echo $og_url; ?>">
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-5M538168N4" nonce="<?php echo $nonce; ?>" SameSite=None; Secure></script>
-    <script nonce="<?php echo $nonce; ?>" SameSite=None; Secure>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-5M538168N4" nonce="<?php echo $nonce; ?>"></script>
+    <script nonce="<?php echo $nonce; ?>">
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());


### PR DESCRIPTION
## Summary
- update script tags in `header.php` and `footer.php` to drop `SameSite=None; Secure`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848301fc09483248bc94528873d489f