### PR TITLE
Add fallback image handler

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'"></a>
+                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'" @error="imgError"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  

--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -30,6 +30,9 @@ var oproepjes= new Vue({
                     console.log(error);
                 });            
         },
+        imgError: function(event){
+            event.target.src = 'img/fallback.svg';
+        },
         set_page_number: function(page){
             if(page <= 1){
                 this.page= 1;

--- a/js/profile.js
+++ b/js/profile.js
@@ -31,6 +31,9 @@ var profiel= new Vue({
     computed: {
     },
     methods:  {
+        imgError: function(event){
+            event.target.src = 'img/fallback.svg';
+        },
         init: function(){
             if(this.profile_id <= 0){
                 return;

--- a/profile.php
+++ b/profile.php
@@ -9,7 +9,7 @@
         <hr>
         <div class="row">
             <div class="col-sm-4 text-center">
-                <img class="profile-pic" :src="profile.profile_image_big" :alt="'Dating in ' + profile.province + ' met ' + profile.name" :title="'Profielfoto van ' + profile.name">
+                <img class="profile-pic" :src="profile.profile_image_big" :alt="'Dating in ' + profile.province + ' met ' + profile.name" :title="'Profielfoto van ' + profile.name" @error="imgError">
             </div>
             <div class="col-sm-8">
                 <h4>Over {{ profile.name }}:</h4>


### PR DESCRIPTION
## Summary
- display a default image for profile listings when the original image fails to load
- use `fallback.svg` instead of `logo.png` for missing images

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684848faf36083248b9317d127ab63cd