### PR TITLE
Add fallback for broken API images

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'"></a>
+                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'" @error="imgError"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  

--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -24,11 +24,23 @@ var oproepjes= new Vue({
         init: function(){
             axios.get(api_url)
                 .then(function(response){
-                    oproepjes.profiles= response.data.profiles;
+                    var profs = response.data.profiles;
+                    profs.forEach(function(p){
+                        if(p.src && p.src.indexOf('no_img_Vrouw.jpg') !== -1){
+                            p.src = 'img/fallback.svg';
+                        }
+                        if(p.profile_image_big && p.profile_image_big.indexOf('no_img_Vrouw.jpg') !== -1){
+                            p.profile_image_big = 'img/fallback.svg';
+                        }
+                    });
+                    oproepjes.profiles = profs;
                 })
                 .catch(function (error) {
                     console.log(error);
-                });            
+                });
+        },
+        imgError: function(event){
+            event.target.src = 'img/fallback.svg';
         },
         set_page_number: function(page){
             if(page <= 1){

--- a/js/profile.js
+++ b/js/profile.js
@@ -31,6 +31,9 @@ var profiel= new Vue({
     computed: {
     },
     methods:  {
+        imgError: function(event){
+            event.target.src = 'img/fallback.svg';
+        },
         init: function(){
             if(this.profile_id <= 0){
                 return;
@@ -38,11 +41,14 @@ var profiel= new Vue({
             let that= this;
             axios.get(api_url + this.profile_id)
                 .then(function(response){
-                    that.profile= response.data.profile;
+                    that.profile = response.data.profile;
+                    if (that.profile.profile_image_big && that.profile.profile_image_big.indexOf('no_img_Vrouw.jpg') !== -1) {
+                        that.profile.profile_image_big = 'img/fallback.svg';
+                    }
                 })
                 .catch(function (error) {
                     console.log(error);
-                });            
+                });
         },
     }
 });

--- a/profile.php
+++ b/profile.php
@@ -9,7 +9,7 @@
         <hr>
         <div class="row">
             <div class="col-sm-4 text-center">
-                <img class="profile-pic" :src="profile.profile_image_big" :alt="'Dating in ' + profile.province + ' met ' + profile.name" :title="'Profielfoto van ' + profile.name">
+                <img class="profile-pic" :src="profile.profile_image_big" :alt="'Dating in ' + profile.province + ' met ' + profile.name" :title="'Profielfoto van ' + profile.name" @error="imgError">
             </div>
             <div class="col-sm-8">
                 <h4>Over {{ profile.name }}:</h4>

--- a/provincie.php
+++ b/provincie.php
@@ -30,7 +30,7 @@
            v-for="profile in filtered_profiles"
           >
         <div class="card h-100">
-            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Daten in ' + profile.province + ' met ' + profile.name" :title="'Bekijk het profiel van ' + profile.name + ' uit ' + profile.city"></a>
+            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Daten in ' + profile.province + ' met ' + profile.name" :title="'Bekijk het profiel van ' + profile.name + ' uit ' + profile.city" @error="imgError"></a>
             <div class="card-body">
               <div class="card-top">
                   <h4 class="card-title">{{ profile.name }}</h4>  


### PR DESCRIPTION
## Summary
- replace placeholder `no_img_Vrouw.jpg` from the API with `img/fallback.svg`
- apply the same check on individual profiles and listings
- attach `imgError` handler on province listings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684848faf36083248b9317d127ab63cd