### PR TITLE
Fix cookie banner visibility

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -35,6 +35,7 @@
        }
 ?>
 
+</div>
 <div id="cookie-banner" style="position: fixed; bottom: 0; left: 0; right: 0; background: #fff; border-top: 1px solid #ccc; font-family: Arial, sans-serif; padding: 20px; z-index: 10000; display: none;">
   <div style="max-width: 960px; margin: auto;">
     <p style="margin-bottom: 10px;">We use cookies to personalize content and ads, to provide social media features and to analyze our traffic. For more details, see our <a href="/cookie-policy.html" target="_blank">Cookie Policy</a>.</p>

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -11,7 +11,7 @@ function setCookieConsent(statistics, marketing) {
 function getCookieConsent() {
   try {
     return JSON.parse(localStorage.getItem('cookieConsent'));
-  } catch {
+  } catch (err) {
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- close `#oproepjes` container before cookie banner markup
- update cookie banner script for broader browser support

## Testing
- `npm test` *(fails: Missing script)*
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_68486c4c3d3c8324bb6a5ada8040d0a3