### PR TITLE
Fix duplicate method in oproepjes.js

### DIFF
--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -42,9 +42,6 @@ var oproepjes= new Vue({
         imgError: function(event){
             event.target.src = 'img/fallback.svg';
         },
-        imgError: function(event){
-            event.target.src = 'img/fallback.svg';
-        },
         set_page_number: function(page){
             if(page <= 1){
                 this.page= 1;


### PR DESCRIPTION
## Summary
- remove redundant `imgError` definition in `oproepjes.js`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684875c740d08324af76c0e748e8749d