### PR TITLE
Use slugged profile URLs

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -61,8 +61,24 @@ $nonce = base64_encode(random_bytes(16));
             $title = "Dating " . $item;
         } else if (isset($_GET['id']) && !empty($_GET['id'])) {
             $id = htmlspecialchars($_GET['id']);
-            $canonicalUrl = $baseUrl . "/profile?id=" . $id;
-            $title = "Daten met " . $id;
+
+            $profileData = @file_get_contents("https://16hl07csd16.nl/profile/get0/8/" . $id);
+            if ($profileData !== false) {
+                $json = json_decode($profileData, true);
+                if (isset($json['profile']['name'])) {
+                    $profileName = $json['profile']['name'];
+                    $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $profileName));
+                    $slug = trim($slug, '-');
+                    $canonicalUrl = $baseUrl . "/daten-met-" . $slug;
+                    $title = "Daten met " . $profileName;
+                } else {
+                    $canonicalUrl = $baseUrl . "/profile?id=" . $id;
+                    $title = "Daten met " . $id;
+                }
+            } else {
+                $canonicalUrl = $baseUrl . "/profile?id=" . $id;
+                $title = "Daten met " . $id;
+            }
         } else if (isset($_GET['tip']) && !empty($_GET['tip'])) {
             $tip = htmlspecialchars($_GET['tip']);
             $canonicalUrl = $baseUrl . "/datingtips-" . $tip;

--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'" @error="imgError"></a>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'" @error="imgError"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  
@@ -35,7 +35,7 @@
                         <li class="list-group-item">Provincie: {{ profile.province }}</li>
                     </ul>
                 </div>
-                <a :href="'profile.php?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
             </div>
         </div>
 

--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -42,6 +42,13 @@ var oproepjes= new Vue({
         imgError: function(event){
             event.target.src = 'img/fallback.svg';
         },
+        slugify: function(text){
+            return text.toString().toLowerCase()
+                .replace(/\s+/g,'-')
+                .replace(/[^a-z0-9-]/g,'')
+                .replace(/--+/g,'-')
+                .replace(/^-+|-+$/g,'');
+        },
         set_page_number: function(page){
             if(page <= 1){
                 this.page= 1;

--- a/provincie.php
+++ b/provincie.php
@@ -30,7 +30,7 @@
            v-for="profile in filtered_profiles"
           >
         <div class="card h-100">
-            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Daten in ' + profile.province + ' met ' + profile.name" :title="'Bekijk het profiel van ' + profile.name + ' uit ' + profile.city" @error="imgError"></a>
+            <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Daten in ' + profile.province + ' met ' + profile.name" :title="'Bekijk het profiel van ' + profile.name + ' uit ' + profile.city" @error="imgError"></a>
             <div class="card-body">
               <div class="card-top">
                   <h4 class="card-title">{{ profile.name }}</h4>  
@@ -42,7 +42,7 @@
                 <li class="list-group-item">Provincie: {{ profile.province }}</li>
               </ul>
             </div>
-            <a :href="'profile.php?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
+            <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
       </div>
     </div><!-- /.row -->


### PR DESCRIPTION
## Summary
- fetch profile name in `header.php` to build canonical URL with slug
- generate slug from JS for profile links
- link to profile pages using new `daten-met-{slug}?id=` pattern

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68487dacaa1c8324ac19806bd6f6e171