### PR TITLE
Add footer links to privacy and cookie policy

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -211,6 +211,13 @@ footer {
     font-size: 1rem;
     font-weight: 400;
 }
+.policy-links {
+    display: block;
+    margin-top: 5px;
+}
+.policy-links a {
+    color: #ffffff;
+}
 /* Social */
 .addthis_inline_follow_toolbox {
     margin-top: -10px;

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -10,7 +10,8 @@
         <li><a href="https://e-notifyer.nl/" target="_blank" class="m-0">E-notifyer</a> - </li>
 		<li><a href="partnerlinks" class="m-0">Meer partnerlinks...</a></li>
 	</ul>
-  	<span class="sub-text">Copyright &copy; <?php echo date('Y'); ?> <?php echo $companyName; ?> | De gratis datingsite van Nederland </span>
+       <span class="sub-text">Copyright &copy; <?php echo date('Y'); ?> <?php echo $companyName; ?> | De gratis datingsite van Nederland </span>
+       <span class="policy-links"><a href="/privacy.php">Privacybeleid</a> | <a href="/cookie-policy.php">Cookiebeleid</a></span>
 </footer>
 <script src="js/vendor/vue.2.5.13.min.js"></script>
 <script src="js/vendor/axios.0.17.1.min.js"></script>


### PR DESCRIPTION
## Summary
- link to privacy policy and cookie policy pages from the footer
- style policy links in CSS

## Testing
- `npm run start` *(fails: `node_modules/.bin/gulp: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68488c73ce1c8324ab70334856fe0868