### PR TITLE
Fix canonical override

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -99,6 +99,10 @@
     if (strpos($title, 'Oproepjes Nederland') === false) {
         $title .= ' - Oproepjes Nederland';
     }
+    // Allow individual pages to override the canonical URL when provided
+    if (isset($canonical) && filter_var($canonical, FILTER_VALIDATE_URL)) {
+        $canonicalUrl = $canonical;
+    }
     echo '<link rel="canonical" href="' . $canonicalUrl . '" >';
     echo '<title>' . $title . '</title>';
 ?>


### PR DESCRIPTION
## Summary
- let pages override `$canonicalUrl` in header

## Testing
- `npm test` *(fails: Missing script)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d14d5d618832487360020d10fb140