### PR TITLE
Fix OG URL fallback

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -191,6 +191,10 @@
             break;
         }
     }
+    // When no match is found, ensure the OG URL follows the canonical URL
+    if ($og_url === $default_url) {
+        $og_url = $canonicalUrl;
+    }
     // Override Open Graph description when a specific meta description is provided
     if (isset($metaDescription) && !empty($metaDescription)) {
         $og_description = htmlspecialchars($metaDescription, ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
## Summary
- ensure OG URL falls back to canonical URL when no page match is found

## Testing
- `npm test` *(fails: Missing script and network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_685d17b6f72883248e78b3ced0bf4d13